### PR TITLE
error payload is an array of errors

### DIFF
--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -235,9 +235,9 @@ defmodule Absinthe.GraphqlWS.Transport do
         socket = merge_opts(socket, context: context)
         {:reply, :ok, {:text, Message.Next.new(id, reply)}, socket}
 
-      {:ok, %{errors: _} = reply, context} ->
+      {:ok, %{errors: errors}, context} ->
         socket = merge_opts(socket, context: context)
-        {:reply, :ok, {:text, Message.Error.new(id, reply)}, socket}
+        {:reply, :ok, {:text, Message.Error.new(id, errors)}, socket}
 
       {:error, reply} ->
         {:reply, :error, {:text, Message.Error.new(id, reply)}, socket}

--- a/test/integration/socket_test.exs
+++ b/test/integration/socket_test.exs
@@ -262,6 +262,35 @@ defmodule Absinthe.GraphqlWS.SocketTest do
       Absinthe.Subscription.publish(Test.Site.Endpoint, %{name: "true"}, thing_changes: "2")
       assert {:ok, []} = Test.Client.get_new_replies(client)
     end
+
+    test "correct error payload for subscription failure", %{client: client} do
+      id = "subscription-with-error"
+
+      :ok =
+        Test.Client.push(client, %{
+          id: id,
+          type: "subscribe",
+          payload: %{
+            query: """
+            subscription HandleError {
+              handleError {
+                id
+                name
+              }
+            }
+            """
+          }
+        })
+
+      assert_json_received(
+        client,
+        %{
+          "id" => "subscription-with-error",
+          "payload" => [%{"locations" => [%{"column" => 3, "line" => 2}], "message" => "subscribe error"}],
+          "type" => "error"
+        }
+      )
+    end
   end
 
   describe "handle_message callbacks" do

--- a/test/support/test/site.ex
+++ b/test/support/test/site.ex
@@ -81,6 +81,12 @@ defmodule Test.Site do
         resolve(&Resolvers.changes_subscription/3)
       end
 
+      field :handle_error, :thing do
+        config(fn _, _ ->
+          {:error, "subscribe error"}
+        end)
+      end
+
       field :handle_message, :boolean do
         arg(:subscription_param, :string)
 


### PR DESCRIPTION
The error payload is actually of type `GraphQLError[]` ([ref](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error)) - so we should extract the inner `errors` value.

P.S. Great library!