### PR TITLE
fix absinthe_graphql_ws install instructions

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -6,7 +6,7 @@ Add `absinthe_graphql_ws` to deps:
 def deps do
   [
     {:absinthe, "~> 1.6"},
-    {:absinthe_graphql_ws, github: "geometerio/absinteh_graphql_ws"},
+    {:absinthe_graphql_ws, github: "geometerio/absinthe_graphql_ws"},
     {:jason, "~> 1.2"}, # or compatible JSON library
     {:phoenix, "~> 1.5"}
     # ...


### PR DESCRIPTION
The package name is incorrect