### PR TITLE
Add optional_callback `handle_ping`

### DIFF
--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -185,7 +185,29 @@ defmodule Absinthe.GraphqlWS.Socket do
   """
   @callback handle_init(payload :: map(), socket()) :: Socket.init()
 
-  @optional_callbacks handle_message: 2, handle_init: 2
+  @doc """
+  Handle a `ping` message sent by the socket client. This will receive the
+  `payload` from the message, defaulting to an empty map.
+
+  This can be useful for monitoring connections and network metrics.
+
+  It must return `{:ok, socket}`, as the protocol spec requires a Pong message
+  must be sent in reply to a Ping as soon as possible.
+
+  ## Example
+
+      defmodule MySocket do
+        use Absinthe.GraphqlWS.Socket, schema: MySchema
+
+        def handle_ping(%{"hello" => "world"}, socket) do
+          socket = assign(socket, :last_ping, :os.system_time(:seconds))
+          {:ok, socket}
+        end
+      end
+  """
+  @callback handle_ping(payload :: map(), socket()) :: {:ok, socket()}
+
+  @optional_callbacks handle_message: 2, handle_init: 2, handle_ping: 2
 
   @spec __after_compile__(any(), any()) :: :ok
   def __after_compile__(env, _bytecode) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -165,8 +165,19 @@ defmodule Absinthe.GraphqlWS.Transport do
     end
   end
 
-  def handle_inbound(%{"type" => "ping"}, socket),
-    do: {:reply, :ok, {:text, Message.Pong.new()}, socket}
+  def handle_inbound(%{"type" => "ping"} = message, socket) do
+    payload = Map.get(message, "payload", %{})
+
+    socket =
+      if function_exported?(socket.handler, :handle_ping, 2) do
+        {:ok, socket} = socket.handler.handle_ping(payload, socket)
+        socket
+      else
+        socket
+      end
+
+    {:reply, :ok, {:text, Message.Pong.new(payload)}, socket}
+  end
 
   def handle_inbound(msg, socket) do
     warn("unhandled message #{inspect(msg)}")

--- a/test/support/test/site.ex
+++ b/test/support/test/site.ex
@@ -14,6 +14,12 @@ defmodule Test.Site do
       Test.Site.TestPubSub.notify(:handle_message_callback, {:subscription, params})
       {:ok, socket}
     end
+
+    @impl Absinthe.GraphqlWS.Socket
+    def handle_ping(payload, socket) do
+      Test.Site.TestPubSub.notify(:handle_ping_callback, {:ping, payload})
+      {:ok, socket}
+    end
   end
 
   defmodule Resolvers do


### PR DESCRIPTION
The graphql-ws spec mentions a [Ping](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping) message may be useful for detecting failed connections or other types of network probing.

To allow an application to hook into this feature, this PR adds:

- An optional `handle_ping` callback in the socket implementation.
- Updates the `Pong` response to include the same `payload` that was sent in the `Ping`.