### PR TITLE
Close socket if handle_init returns an :error

### DIFF
--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -175,7 +175,7 @@ defmodule Absinthe.GraphqlWS.Socket do
         def handle_init(%{"user_id" => user_id}, socket) do
           case find_user(user_id) do
             nil ->
-              {:error, %{}, socket}
+              {:error, socket, "Forbidden"}
             user ->
               socket = assign_context(socket, current_user: user)
               {:ok, %{name: user.name}, socket}

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -175,7 +175,7 @@ defmodule Absinthe.GraphqlWS.Socket do
         def handle_init(%{"user_id" => user_id}, socket) do
           case find_user(user_id) do
             nil ->
-              {:error, socket, "Forbidden"}
+              {:error, "Forbidden", socket}
             user ->
               socket = assign_context(socket, current_user: user)
               {:ok, %{name: user.name}, socket}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -126,8 +126,11 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
-        {:error, payload, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
+          {:error, socket} ->
+            close(4403, "Forbidden", socket)
+
+          {:error, message, socket} ->
+            close(4403, message, socket)
       end
     else
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, %{socket | initialized?: true}}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -201,8 +201,10 @@ defmodule Absinthe.GraphqlWS.Transport do
     end
   end
 
-  defp close(code, message, socket) do
-    {:reply, :ok, {:close, code, message}, socket}
+  defp close(code, _message, socket) do
+    # This seems to crash the websocket handler.
+    # {:reply, :ok, {:close, code, message}, socket}
+    {:reply, :ok, {:close, code}, socket}
   end
 
   defp parse_query(%{"query" => query}) when is_binary(query), do: {:ok, query}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -201,10 +201,8 @@ defmodule Absinthe.GraphqlWS.Transport do
     end
   end
 
-  defp close(code, _message, socket) do
-    # This seems to crash the websocket handler.
-    # {:reply, :ok, {:close, code, message}, socket}
-    {:reply, :ok, {:close, code}, socket}
+  defp close(code, message, socket) do
+    {:stop, :normal, {code, message}, socket}
   end
 
   defp parse_query(%{"query" => query}) when is_binary(query), do: {:ok, query}

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule AbsintheGraphqlWS.MixProject do
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:gun, "~> 1.3", only: [:test]},
       {:jason, "~> 1.2", optional: true},
-      {:markdown_formatter, "~> 0.5"},
+      {:markdown_formatter, "~> 0.5", only: :dev, runtime: false},
       {:mix_audit, "~> 1.0", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.5"},
       {:plug_cowboy, "~> 2.5", only: :test, override: true}


### PR DESCRIPTION
The current docs suggest returning `{:error, %{}, socket}` from `handle_init`.
https://github.com/geometerio/absinthe_graphql_ws/blob/b98d3deb15febd856725f69b7a54c38e3b67ab3b/lib/absinthe/graphql_ws/socket.ex#L176-L178

This ends up creating an invalid error message:
https://github.com/geometerio/absinthe_graphql_ws/blob/b98d3deb15febd856725f69b7a54c38e3b67ab3b/lib/absinthe/graphql_ws/transport.ex#L129-L130
https://github.com/geometerio/absinthe_graphql_ws/blob/b98d3deb15febd856725f69b7a54c38e3b67ab3b/lib/absinthe/graphql_ws/message/error.ex#L9-L11

The error message will be `type: "error", id: %{}, payload: %{}`, when the spec expects the id to be a string, and payload to be an array of graphql errors. The client currently throws an error when it sees this invalid message.

Even if you fix this, the spec does not expect an error message in response to `connection_init`, and the official client will also throw an error.

The reference implementation closes the connection with code 4403 if handling `connection_init` fails:
https://github.com/enisdenjo/graphql-ws/blob/799cfc7bbe0f6d1a5c90b4880f02c58c5c3a06d4/src/server.ts#L612-L614

https://github.com/enisdenjo/graphql-ws/blob/799cfc7bbe0f6d1a5c90b4880f02c58c5c3a06d4/src/__tests__/server.ts#L437-L458

This is critical for token refresh based workflows (e.g. the token you included in `connectionParams` on the client is stale, and you need to check for 4403 Forbidden to refresh it).

This PR matches the spec. I'm not sure how to adapt the tests to check for this, suggestions welcome!