### PR TITLE
Fix wrong key used to delete subscriptions from socket

### DIFF
--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -158,7 +158,7 @@ defmodule Absinthe.GraphqlWS.Transport do
         Phoenix.PubSub.unsubscribe(socket.pubsub, topic)
         Absinthe.Subscription.unsubscribe(socket.endpoint, topic)
 
-        {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, id)}}
+        {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
       _ ->
         {:ok, socket}


### PR DESCRIPTION
`subscriptions` maps topics to subscription ids, so we must delete the topic from the map to remove a subscription