### PR TITLE
Logger.warn -> Logger.warning

### DIFF
--- a/lib/absinthe/graphql_ws/client.ex
+++ b/lib/absinthe/graphql_ws/client.ex
@@ -198,5 +198,5 @@ defmodule Absinthe.GraphqlWS.Client do
   end
 
   # defp debug(msg), do: Logger.debug("[client@#{inspect(self())}] #{msg}")
-  defp warn(msg), do: Logger.warn("[client@#{inspect(self())}] #{msg}")
+  defp warn(msg), do: Logger.warning("[client@#{inspect(self())}] #{msg}")
 end

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -24,7 +24,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   @type socket() :: Socket.t()
 
   defmacrop debug(msg), do: quote(do: Logger.debug("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
-  defmacrop warn(msg), do: quote(do: Logger.warn("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
+  defmacrop warn(msg), do: quote(do: Logger.warning("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
 
   @doc """
   Generally this will only receive `:pong` messages in response to our keepalive


### PR DESCRIPTION
Fixes compile warnings in Elixir 1.15. [Context for this deprecation](https://jeffkreeftmeijer.com/elixir-backwards-compatible-logger/)