### PR TITLE
BREAKING!: Change default Error payload parameter and add ability to close

### DIFF
--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -128,6 +128,7 @@ defmodule Absinthe.GraphqlWS.Socket do
           {:ok, map(), socket()}
           | {:error, {String.t(), map()}, socket()}
           | {:error, map(), socket()}
+          | {:close, {number(), String.t()}, socket()}
           | {:stop, term(), socket()}
 
   @doc """

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -126,6 +126,7 @@ defmodule Absinthe.GraphqlWS.Socket do
   """
   @type init() ::
           {:ok, map(), socket()}
+          | {:error, {String.t(), map()}, socket()}
           | {:error, map(), socket()}
           | {:stop, term(), socket()}
 

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -126,6 +126,9 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
+        {:error, {id, payload}, socket} ->
+          {:reply, :ok, {:text, Message.Error.new(id, payload)}, socket}
+
         {:error, payload, socket} ->
           {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
       end

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   their codebase, but is documented to help understand the intentions of the code.
   """
 
-  alias Absinthe.GraphqlWS.{Message, Socket, Util, Uuid}
+  alias Absinthe.GraphqlWS.{Message, Socket, Util}
   alias Phoenix.Socket.Broadcast
   require Logger
 
@@ -126,8 +126,11 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
+        {:error, {id, payload}, socket} ->
+          {:reply, :ok, {:text, Message.Error.new(id, payload)}, socket}
+
         {:error, payload, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(Uuid.generate(), payload)}, socket}
+          {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
       end
     else
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, %{socket | initialized?: true}}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   their codebase, but is documented to help understand the intentions of the code.
   """
 
-  alias Absinthe.GraphqlWS.{Message, Socket, Util}
+  alias Absinthe.GraphqlWS.{Message, Socket, Util, Uuid}
   alias Phoenix.Socket.Broadcast
   require Logger
 
@@ -126,8 +126,11 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
+        {:error, {id, payload}, socket} ->
+          {:reply, :ok, {:text, Message.Error.new(id, payload)}, socket}
+
         {:error, payload, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
+          {:reply, :ok, {:text, Message.Error.new(Uuid.generate(), payload)}, socket}
       end
     else
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, %{socket | initialized?: true}}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -126,9 +126,6 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
-        {:error, {id, payload}, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(id, payload)}, socket}
-
         {:error, payload, socket} ->
           {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
       end

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -131,6 +131,9 @@ defmodule Absinthe.GraphqlWS.Transport do
 
         {:error, payload, socket} ->
           {:reply, :ok, {:text, Message.Error.new(Uuid.generate(), payload)}, socket}
+
+        {:close, {status, message}, socket} ->
+          close(status, message, socket)
       end
     else
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, %{socket | initialized?: true}}

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   their codebase, but is documented to help understand the intentions of the code.
   """
 
-  alias Absinthe.GraphqlWS.{Message, Socket, Util}
+  alias Absinthe.GraphqlWS.{Message, Socket, Util, Uuid}
   alias Phoenix.Socket.Broadcast
   require Logger
 
@@ -126,11 +126,8 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, %{socket | initialized?: true}}
 
-        {:error, {id, payload}, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(id, payload)}, socket}
-
         {:error, payload, socket} ->
-          {:reply, :ok, {:text, Message.Error.new(payload)}, socket}
+          {:reply, :ok, {:text, Message.Error.new(Uuid.generate(), payload)}, socket}
       end
     else
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, %{socket | initialized?: true}}


### PR DESCRIPTION
With current implementation there are no ability to provide message payload and no ability to close a socket.

With this default is to use `payload` from `{:error, payload, socket}` as a `Message.Error` payload and automatically generate `Message.Error` UUID. When provided with `{:error, {id, payload}, socket}`,  `Message.Error` would be constructed with id and payload.

When returning `{:close, {status, message}, socket`, connection is closed.

Fixes https://github.com/geometerio/absinthe_graphql_ws/issues/23