### PR TITLE
chore: add keepalive timestamps

### DIFF
--- a/lib/absinthe/graphql_ws/client.ex
+++ b/lib/absinthe/graphql_ws/client.ex
@@ -198,5 +198,5 @@ defmodule Absinthe.GraphqlWS.Client do
   end
 
   # defp debug(msg), do: Logger.debug("[client@#{inspect(self())}] #{msg}")
-  defp warn(msg), do: Logger.warn("[client@#{inspect(self())}] #{msg}")
+  defp warn(msg), do: Logger.warning("[client@#{inspect(self())}] #{msg}")
 end

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -24,7 +24,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   @type socket() :: Socket.t()
 
   defmacrop debug(msg), do: quote(do: Logger.debug("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
-  defmacrop warn(msg), do: quote(do: Logger.warn("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
+  defmacrop warn(msg), do: quote(do: Logger.warning("[graph-socket@#{inspect(self())}] #{unquote(msg)}"))
 
   @doc """
   Generally this will only receive `:pong` messages in response to our keepalive

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -40,7 +40,8 @@ defmodule Absinthe.GraphqlWS.Transport do
     measurements = %{duration: System.monotonic_time() - start}
     metadata = %{}
     :telemetry.execute([:absinthe_graphql_ws, :keepalive, :stop], measurements, metadata)
-    socket = Util.assign(socket, last_inbound_pong: System.system_time())
+    system_time = System.system_time()
+    socket = Util.assign(socket, last_inbound_pong: system_time, last_keepalive: system_time)
 
     {:ok, socket}
   end
@@ -93,7 +94,8 @@ defmodule Absinthe.GraphqlWS.Transport do
     measurements = %{system_time: System.system_time()}
     metadata = %{}
     :telemetry.execute([:absinthe_graphql_ws, :keepalive, :start], measurements, metadata)
-    socket = Util.assign(socket, start: start, last_outbound_ping: System.system_time())
+    system_time = System.system_time()
+    socket = Util.assign(socket, start: start, last_outbound_ping: system_time, last_keepalive: system_time)
 
     {:push, {:ping, @ping}, socket}
   end
@@ -199,7 +201,8 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   def handle_inbound(%{"type" => "ping"}, socket) do
-    socket = Util.assign(socket, last_inbound_ping: System.system_time())
+    system_time = System.system_time()
+    socket = Util.assign(socket, last_inbound_ping: system_time, last_keepalive: system_time)
     {:reply, :ok, {:text, Message.Pong.new()}, socket}
   end
 

--- a/test/support/test/client.ex
+++ b/test/support/test/client.ex
@@ -129,5 +129,5 @@ defmodule Test.Client do
   end
 
   defp debug(msg), do: Logger.debug("[client@#{inspect(self())}] #{msg}")
-  defp warn(msg), do: Logger.warn("[client@#{inspect(self())}] #{msg}")
+  defp warn(msg), do: Logger.warning("[client@#{inspect(self())}] #{msg}")
 end


### PR DESCRIPTION
Store in the socket's assigns the timestamp each time we send or receive a keepalive (ping/pong) message.